### PR TITLE
Reset DHCP/Autodiscover IP-Adresses

### DIFF
--- a/functions/classes/class.phpipamAgent.php
+++ b/functions/classes/class.phpipamAgent.php
@@ -1075,7 +1075,6 @@ class phpipamAgent extends Common_functions {
 			$this->Database = new Database_PDO ($this->config->db['user'], $this->config->db['pass'], $this->config->db['host'], $this->config->db['port'], $this->config->db['name']);
 		}
 		// loop
-		print_r($subnets);
 		foreach ($subnets as $s) {
 			if (sizeof($s->discovered)>0) {
 				foreach ($s->discovered as $ip) {

--- a/functions/classes/class.phpipamAgent.php
+++ b/functions/classes/class.phpipamAgent.php
@@ -1066,7 +1066,7 @@ class phpipamAgent extends Common_functions {
 	 *
 	 * @access private
 	 * @param mixed $subnets
-	 * @return voi
+	 * @return void
 	 */
 	private function mysql_scan_update_write_to_db ($subnets) {
 		# reset db connection for ping / pear


### PR DESCRIPTION
Hello Miha,

I have written a little php-function called "reset_dhcp_addresses".
To make it short it does the following:

It will reset the DHCP-Adresses if the time-diff from "lastSeen" (IPs) and  now ( time() ) is greater than pingStatus (settings).

In my company everything (DHCP, DNS etc.) is done fully automatic and with this new function phpipam can get all information (even deleted machines) from itself.
Maybe its also usefull to you ;)

Best regards,
Maximilian Herrmann
Systemadministrator | Infrastructure

Edit:
reset_autodiscover_addresses -> IF in description-string is "-- autodiscovered --" it will be deleted like the dhcp addresses
With those two functions subnets can manage themself.