### PR TITLE
move to next index always

### DIFF
--- a/functions/classes/class.phpipamAgent.php
+++ b/functions/classes/class.phpipamAgent.php
@@ -781,10 +781,10 @@ class phpipamAgent extends Common_functions {
 		    	//only if index exists!
 		    	if(isset($subnets[$z])) {
 					//start new thread
-		            $threads[$z] = new Thread( 'fping_subnet' );
-					$threads[$z]->start_fping( $this->transform_to_dotted($subnets[$z]->subnet)."/".$subnets[$z]->mask );
-		            $z++;				//next index
-				}
+		        $threads[$z] = new Thread( 'fping_subnet' );
+					  $threads[$z]->start_fping( $this->transform_to_dotted($subnets[$z]->subnet)."/".$subnets[$z]->mask );
+				  }
+          $z++;				//next index
 		    }
 		    // wait for all the threads to finish
 		    while( !empty( $threads ) ) {


### PR DESCRIPTION
DO NOT merge without testing further. I have only seen this on a single server out of the 8 I have.

The problem I saw is that the first subnet sets returned by _mysql_fetch_subnets_ was empty. Because of this the **$z** variable was never increased and all the subsequent subnets were not scanned. 

Moving the variable outside the **if** does makes sense and it has resolved my problem.
