### PR TITLE
bugfix on syntax warning

### DIFF
--- a/functions/classes/class.phpipamAgent.php
+++ b/functions/classes/class.phpipamAgent.php
@@ -440,7 +440,7 @@ class phpipamAgent extends Common_functions {
 	 */
 	public function execute () {
 		// initialize proper function
-		$init = initialize_.$this->conn_type;
+		$init = 'initialize_'.$this->conn_type;
 		// init
 		return $this->{$init} ();
 	}


### PR DESCRIPTION
This is to avoid this error:
Warning: Use of undefined constant initialize_ - assumed 'initialize_' (this will throw an Error in a future version of PHP) in /phpipam-agent/functions/classes/class.phpipamAgent.php on line 443