### PR TITLE
Make it possible to disable Common Name (CN) verification of the serv…

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -70,4 +70,5 @@ $config['db']['ssl_key']    = '/path/to/cert.key';             // path to an SSL
 $config['db']['ssl_cert']   = '/path/to/cert.crt';             // path to an SSL certificate file. Only makes sense combined with ssl_key
 $config['db']['ssl_ca']     = '/path/to/ca.crt';               // path to a file containing SSL CA certs
 $config['db']['ssl_capath'] = '/path/to/ca_certs';             // path to a directory containing CA certs
-$config['db']['ssl_cipher'] = '/DHE-RSA-AES256-SHA:AES128-SHA'; // one or more SSL Ciphers
+$config['db']['ssl_cipher'] = 'DHE-RSA-AES256-SHA:AES128-SHA'; // one or more SSL Ciphers
+$config['db']['ssl_verify'] = true;                            // Verify Common Name (CN) of server certificate?

--- a/functions/classes/class.PDO.php
+++ b/functions/classes/class.PDO.php
@@ -905,6 +905,10 @@ class Database_PDO extends DB {
 
 			$this->ssl = array();
 
+			if ($config['db']['ssl_verify']===false) {
+				$this->ssl[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = false;
+			}
+
 			foreach ($this->pdo_ssl_opts as $key => $pdoopt) {
 				if ($config['db'][$key]) {
 					$this->ssl[$pdoopt] = $config['db'][$key];


### PR DESCRIPTION
…ers certificate.

Which cures the dreaded "Could not connect to database! SQLSTATE[HY000] [2002]".

Same error could also be caused by having a mistyped cipher, e.g. the leading slash in '/DHE-RSA-AES256-SHA:AES128-SHA'.