### PR TITLE
Fix check which was using sizeof() operator on single object returned…

### DIFF
--- a/functions/classes/class.Scan.php
+++ b/functions/classes/class.Scan.php
@@ -137,7 +137,7 @@ class Scan extends Common_functions {
 				return false;
 			}
 			# save to cache array
-			if(sizeof($res)>0) {
+			if($res !== null) {
 				$this->table[$table][$method][$id] = (object) $res;
 				return $res;
 			}


### PR DESCRIPTION
… PDO database query, changed check to if ( !== null )

Tracing this up the call stack it was calling (which was returning a single object) :
`public function getObjectQuery($query = null, $values = array(), $class = 'stdClass') {
		if (!$this->isConnected()) $this->connect();

		$statement = $this->pdo->prepare($query);
		//debuq
		$this->log_query ($statement, $values);
		$statement->execute((array)$values);

		$resultObj = $statement->fetchObject($class);

		if ($resultObj === false) {
			return null;
		} else {
			return $resultObj;
		}
	}`

which was calling : 

`
public function getObjectQuery($query = null, $values = array(), $class = 'stdClass') {
		if (!$this->isConnected()) $this->connect();

		$statement = $this->pdo->prepare($query);
		//debuq
		$this->log_query ($statement, $values);
		$statement->execute((array)$values);

		$resultObj = $statement->fetchObject($class);

		if ($resultObj === false) {
			return null;
		} else {
			return $resultObj;
		}
	}
`

Original error was:

Warning: sizeof(): Parameter must be an array or an object that implements Countable in /var/www/phpipam-agent/functions/classes/class.Scan.php on line 140
